### PR TITLE
Fix GlobalStyles selector

### DIFF
--- a/src/components/GlobalStyles/GlobalStyles.js
+++ b/src/components/GlobalStyles/GlobalStyles.js
@@ -124,7 +124,7 @@ button {
     outline-offset: 2px;
   }
 
-  &:focus:not(.focus-visible) {
+  &:focus:not(:focus-visible) {
     outline: none;
   }
 }


### PR DESCRIPTION
Fixing the `&:focus:not(.focus-visible)` selector for buttons to `&:focus:not(:focus-visible)`